### PR TITLE
Build fixes

### DIFF
--- a/src/agg/include/agg_scanline_u.h
+++ b/src/agg/include/agg_scanline_u.h
@@ -458,7 +458,7 @@ namespace agg
     class scanline32_u8_am : public scanline32_u8
     {
     public:
-        typedef scanline_u8           base_type;
+        typedef scanline32_u8           base_type;
         typedef AlphaMask             alpha_mask_type;
         typedef base_type::cover_type cover_type;
         typedef base_type::coord_type coord_type;

--- a/src/render/TextRenderer.h
+++ b/src/render/TextRenderer.h
@@ -176,7 +176,7 @@ private:
 		const Color& selectionFG, const Color& underlineColor);
 
 public:
-	static const double		AUTO_HINT_SCALE = 100.0;
+	static constexpr double	AUTO_HINT_SCALE = 100.0;
 
 private:
 	RenderingBuffer			fBuffer;

--- a/src/render/text/FontRegistry.cpp
+++ b/src/render/text/FontRegistry.cpp
@@ -13,7 +13,7 @@
 
 #include <ft2build.h>
 #include FT_SFNT_NAMES_H
-#include <freetype2/ttnameid.h>
+#include <freetype/ttnameid.h>
 
 #include <Directory.h>
 //#include <Menu.h>

--- a/src/tools/transform/TransformToolState.h
+++ b/src/tools/transform/TransformToolState.h
@@ -189,7 +189,7 @@ struct TransformToolState::DrawParameters {
 
 	BPoint pivot;
 
-	static const float pivotSize = 3;
+	static constexpr float pivotSize = 3;
 
 	DrawParameters(TransformToolState* state, const BRect & modifiedBox,
 		float scaleX, float scaleY, const BPoint & pivot, bool subpixelPrecise)


### PR DESCRIPTION
- Use constexpr for inline constants in .h files
- Fix wrong base class in one of agg headers (it seems Haiku version of
  the agg headers have more fixes, maybe it is wise to update from
  there?)
- Fix freetype include paths

(I just wanted to show Wonderbrush v3 at the Capitole du Libre conference next week, so I needed some binary to work from).