### PR TITLE
gcc8 build fix

### DIFF
--- a/src/agg/include/agg_renderer_outline_aa.h
+++ b/src/agg/include/agg_renderer_outline_aa.h
@@ -1365,7 +1365,6 @@ namespace agg
         //---------------------------------------------------------------------
         void profile(const line_profile_aa& prof) { m_profile = &prof; }
         const line_profile_aa& profile() const { return *m_profile; }
-        line_profile_aa& profile() { return *m_profile; }
 
         //---------------------------------------------------------------------
         int subpixel_width() const { return m_profile->subpixel_width(); }


### PR DESCRIPTION
It's not possible to return a non-const reference to a const member I
think. Fixes build with gcc8.